### PR TITLE
Add server configuration overrides

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,10 +6,18 @@ import { registerPrompts } from "../core/prompts.js";
 // Create and start the MCP server
 async function startServer() {
   try {
+    // Environment overrides for ping interval and health path
+    const pingInterval = parseInt(process.env.PING_INTERVAL || "60000", 10);
+    const healthPath = process.env.HEALTH_PATH || "/health";
+
     // Create a new FastMCP server instance
     const server = new FastMCP({
       name: "Frank Goortani CV MCP Server",
-      version: "1.0.0"
+      version: "1.0.0",
+      instructions: "Describes how to use the CV tools and resources.",
+      ping: { enabled: true, intervalMs: pingInterval },
+      health: { enabled: true, path: healthPath, message: "ok" },
+      roots: { enabled: false }
     });
 
     // Register all resources, tools, and prompts


### PR DESCRIPTION
## Summary
- configure server with instructions, ping, health and roots options
- allow PING_INTERVAL and HEALTH_PATH env vars to override defaults

## Testing
- `npm run build:http`
- `npm run build`