### PR TITLE
Improve error handling for company experience tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Retrieves work experience at a specific company.
 
 - **Parameters**:
   - `company` (string): Company name to get experience for
-- **Returns**: JSON object with matching experiences
+- **Returns**: JSON object with matching experiences. Throws `UserError` if none found.
 
 Example:
 
@@ -173,7 +173,6 @@ const result = await client.callTool("get_company_experience", {
 
 // Response
 {
-  "found": true,
   "experiences": [
     {
       "company": "Uber",

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -1,4 +1,4 @@
-import { FastMCP } from "fastmcp";
+import { FastMCP, UserError } from "fastmcp";
 import { z } from "zod";
 import * as services from "./services/index.js";
 
@@ -661,7 +661,7 @@ export function registerTools(server: FastMCP) {
 
   server.addTool({
     name: "get_company_experience",
-    description: "Get Frank Goortani's experience at a specific company",
+    description: "Get Frank Goortani's experience at a specific company. Throws UserError if none found.",
     parameters: z.object({
       company: z.string().describe("Company name to get experience for")
     }),
@@ -671,11 +671,11 @@ export function registerTools(server: FastMCP) {
         exp.company.toLowerCase().includes(companyName)
       );
 
-      const result = companyExperiences.length === 0
-        ? { found: false, message: `No experience found for company: ${params.company}` }
-        : { found: true, experiences: companyExperiences };
+      if (companyExperiences.length === 0) {
+        throw new UserError(`No experience found for company: ${params.company}`);
+      }
 
-      return JSON.stringify(result);
+      return JSON.stringify({ experiences: companyExperiences });
     }
   });
 


### PR DESCRIPTION
## Summary
- import `UserError` in tools
- throw `UserError` in `get_company_experience` when no matches
- update README to document new behavior

## Testing
- `npm run build`