### PR TITLE
Add API key authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Development Notes
+
+- Use TypeScript strict mode. Run `npx tsc --noEmit` to verify the project compiles.
+- There is no test suite but run `npm test` to show missing script output in PRs.
+- Start scripts rely on Bun (`bun run start`) or Node; keep compatibility with existing scripts.
+- Document environment variables in the README when changing configuration.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The project uses the following environment variables that can be configured:
 - `PORT`: HTTP port for local development (default: 3001)
 - `HOST`: Host binding for HTTP server (default: 0.0.0.0)
 - `ENVIRONMENT`: Current environment (development/production)
+- `API_KEY`: API key required in the `x-api-key` header for all requests
 
 In Cloudflare, these variables are configured in the `wrangler.toml` file:
 
@@ -331,8 +332,10 @@ ENVIRONMENT = "development"
 npx fastmcp dev "bun run start"
 
 # Connect via HTTP transport
-npx fastmcp connect http://localhost:3001/sse
+npx fastmcp connect http://localhost:3001/sse -H "x-api-key:<your-api-key>"
 ```
+
+Make sure to replace `<your-api-key>` with the value of the `API_KEY` environment variable.
 
 #### Connecting from Cursor
 

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
  * Register all prompts with the MCP server
  * @param server The FastMCP server instance
  */
-export function registerPrompts(server: FastMCP) {
+export function registerPrompts<T extends Record<string, unknown> | undefined>(server: FastMCP<T>) {
   // Example prompt
   server.addPrompt({
     name: "greeting",

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -9,7 +9,7 @@ import path from 'path';
  * Register all resources with the MCP server
  * @param server The FastMCP server instance
  */
-export function registerResources(server: FastMCP) {
+export function registerResources<T extends Record<string, unknown> | undefined>(server: FastMCP<T>) {
   // Frank Goortani CV markdown resource
   server.addResource({
     uri: "cv://frankgoortani",

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -424,7 +424,7 @@ const cvData = {
  *
  * @param server The FastMCP server instance
  */
-export function registerTools(server: FastMCP) {
+export function registerTools<T extends Record<string, unknown> | undefined>(server: FastMCP<T>) {
   // CV Tools
   server.addTool({
     name: "get_profile",


### PR DESCRIPTION
## Summary
- support API key auth for the FastMCP server
- log authenticated user id on connect/disconnect
- document required API_KEY in README
- add AGENTS.md with dev notes

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*